### PR TITLE
docs: add verbose description and install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Fire Launcher
+# Fire Launcher
 
 ```
   O      , U
@@ -6,24 +6,42 @@ Fire Launcher
   |\  `----'
   L
 ```
-=================
 
-Launcher for FIRE project.
+## About
 
-Using [box](https://github.com/box-project/box) to compile the project.
+The FIRE Launcher is a command-line utility that streamlines the execution of [FIRE (Fast Initialization and Rebuilding of Environments)](https://github.com/fourkitchens/fire/) scripts within your projects. By typing `fire <command>`, this tool dynamically loads and runs the appropriate FIRE scripts for the current project, eliminating the need for global installations. It simplifies your workflow by providing a consistent interface to manage environment setup and project-specific tasks, ensuring rapid and efficient development processes.
 
+## Installing
 
-### Installing
-- Go to the following page https://github.com/fourkitchens/fire-launcher/releases
-- Find the release you are interested in and download the attached Fire.phar file.
-- Now using your terminar go your downloads folder.
-- Now execute `chmod +x fire.phar`
-- And Finally `mv fire.phar /usr/local/bin/fire`
-- now you should be able to trigger the command fire from any directory into you terminal.
+Download the latest stable release or [browse all releases](https://github.com/fourkitchens/fire-launcher/releases) to download specific fire.phar file:
 
-### Compiling
+```Shell
+curl -s https://api.github.com/repos/fourkitchens/fire-launcher/releases/latest \
+| grep "browser_download_url.*fire.phar" \
+| cut -d '"' -f 4 \
+| xargs -I {} curl -L -o fire.phar {}
+```
 
-If you want to compile the fire launcher from the source repo , follow this instructions.
+```Shell
+wget $(curl -s https://api.github.com/repos/fourkitchens/fire-launcher/releases/latest \
+| grep "browser_download_url.*fire.phar" \
+| cut -d '"' -f 4) -O fire.phar
+```
+
+Navigate to the fire.phar file in your terminal to move this file to a globally executable space. On Ubuntu and Other Unix-like Systems (Linux, macOS):
+
+```Shell
+# Make the file executable
+chmod +x fire.phar
+# Move the file to a directory in your PATH, such as /usr/local/bin:
+mv fire.phar /usr/local/bin/fire
+```
+
+You should now be able to trigger the command fire from any directory into you terminal.
+
+## Compiling
+
+Using [box](https://github.com/box-project/box) to compile the project. If you want to compile the fire launcher from the source repo , follow this instructions.
 
 - go to the project root
 - execute the command ```box compile```. I should generate a fire.phar file


### PR DESCRIPTION
# Description of work
- Organize the readme to describe the purpose of the tool at the top and create separate spaces for install and compile.
- Add instruction for installing via command line to remove ambiguity for people joining the project.

# Functional testing
- [ ] Verify that the curl and wget command successfully download the latest fire.phar file.
- [ ] Review other commands for accuracy. This is not a complete set of instruction as it does not consider powershell, homebrew, or other popular install mechanisms -- but it feels like the right level of detail for our audience. 